### PR TITLE
Improvs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ All previews are cached (except for regular images) and stored in your **~/.cach
 
 
 ## Prerequisites
+* bash
 * [ffmpegthumbnailer](https://github.com/dirkvdb/ffmpegthumbnailer)
 * ImageMagick
 * pdftoppm (Available in the AUR as **poppler** package.)

--- a/vifm-sixel
+++ b/vifm-sixel
@@ -1,15 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 [ -d "$HOME/.cache/vifm" ] || mkdir -p "$HOME/.cache/vifm"
 
 # $1 action
 action="$1"
 # $2 panel width
-panel_width=$(($2*6))
 # $3 panel height
-panel_height=$(($3*14))
+panel_width=$2
+panel_height=$3
+cell_width=6
+cell_height=14
+width=$((panel_width*cell_width))
+height=$((panel_height*cell_height))
 # $4 image path
 image_file="$4"
+background=black
 
 PCACHE="$HOME/.cache/vifm/thumbnail.$(stat --printf '%n\0%i\0%F\0%s\0%W\0%Y' -- "$(readlink -f "$PWD/$image_file")" | sha256sum | awk '{print $1}')"
 
@@ -21,7 +26,7 @@ cleanup() {
 
 # recieves image with height
 image() {
-    montage "$1" -geometry "${2}x${3}" sixel:-
+    montage "$1" -background "$background" -geometry "${2}x${3}" sixel:-
   }
 
 
@@ -32,32 +37,32 @@ case "$action" in
   "draw")
     [ ! -f "${PCACHE}.jpg" ] && convert "$image_file"'[0]' "${PCACHE}.jpg"
     # FILE="$PWD/$image_file"
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   "video")
     [ ! -f "${PCACHE}.jpg" ] && \
     ffmpegthumbnailer -i "$4" -o "${PCACHE}.jpg" -s 0 -q 5
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   "epub")
     [ ! -f "${PCACHE}.jpg" ] && \
     epub-thumbnailer "$image_file" "$PCACHE" 1024
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   "pdf")
     [ ! -f "${PCACHE}.jpg" ] && \
     pdftoppm -jpeg -f 1 -singlefile "$image_file" "$PCACHE"
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   "audio")
     [ ! -f "${PCACHE}.jpg" ] && \
     ffmpeg -i "$image_file" "${PCACHE}.jpg" -y >/dev/null
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   "font")
     [ ! -f "${PCACHE}.jpg" ] && \
     fontpreview -i "$image_file" -o "${PCACHE}.jpg"
-    image "${PCACHE}.jpg" "$panel_width" "$panel_height"
+    image "${PCACHE}.jpg" "$width" "$height"
     ;;
   *)
 esac


### PR DESCRIPTION
this is a branch i was working on trying to add stuff from lsix to have detection of terminal size in cols and pixels, from looking at how it gets the terminal properties.

the change to bash is since i have not found any way to properly query the properties and parse them in pure posix shell, another important this is the need to check the terminal cells and rows against the X and Y pixels to calculate the X and Y pixel density of each cell for proper sixel sizing, also getting the background to properly display the images with montage on a properly colored background.

the commands to detect the properties along some echos to show them:
```bash
#!/bin/bash

timeout=0.25  # How long to wait for terminal to respond
              # to a control sequence (in seconds).

# Various terminal automatic configuration routines.

# Don't show escape sequences the terminal doesn't understand.
stty -echo			# Hush-a Mandara Ni Pari

# IS TERMINAL SIXEL CAPABLE?		# Send Device Attributes
old_ifs=$IFS
IFS=";" read -a REPLY -s -t 1 -d "c" -p $'\e[c' >&2
for code in "${REPLY[@]}"; do
  if [[ $code == "4" ]]; then
    echo "$code"
    hassixel=yup
    echo "$hassixel"
    # break
  fi
done
IFS=$old_ifs

# Query the terminal background and foreground colors.
old_ifs=$IFS
IFS=";:/"  read -a REPLY -r -s -t ${timeout} -d "\\" -p $'\e]11;?\e\\' >&2
if [[ ${REPLY[1]} =~ ^rgb ]]; then
  # Return value format: $'\e]11;rgb:ffff/0000/ffff\e\\'.
  # ImageMagick wants colors formatted as #ffff0000ffff.
  background='#'${REPLY[2]}${REPLY[3]}${REPLY[4]%%$'\e'*}
fi
IFS=$old_ifs

echo "$background"

# Send control sequence to query the sixel graphics geometry to
# find out how large of a sixel image can be shown.
old_ifs=$IFS
IFS=";"  read -a REPLY -s -t ${timeout} -d "S" -p $'\e[?2;1;0S' >&2
if [[ ${REPLY[2]} -gt 0 ]]; then
  width=${REPLY[2]}
  height=${REPLY[3]}
fi
IFS=$old_ifs
# else

# Nope. Fall back to dtterm WindowOps to approximate sixel geometry.
old_ifs=$IFS
IFS=";" read -a REPLY -s -t ${timeout} -d "t" -p $'\e[14t' >&2
winwidth=${REPLY[2]}"x"${REPLY[1]}
IFS=$old_ifs
# fi

# returns ^[4;height;widtht
old_ifs=$IFS
IFS=";" read -a REPLY -s -t ${timeout} -d "t" -p $'\e[19t' >&2
dim=${REPLY[2]}"x"${REPLY[1]}
IFS=$old_ifs

echo "$width"
echo "$height"
echo "$winwidth"

echo "$dim"
```

a lot of this was taken directly from lsix

ideally some of these could be cached to not have the need for constantly queriying the properties on every image.